### PR TITLE
Update CSG definition in parser

### DIFF
--- a/myRayTracing/src/scene_file.jl
+++ b/myRayTracing/src/scene_file.jl
@@ -836,6 +836,8 @@ function parse_cone(input_file::InputStream, scene::Scene)::Cone
 
 end
 
+##REDEFINE CSG COMPOSING MULTIPLE SHAPES
+
 """Parse a Union object from tokens"""
 function parse_union(input_file::InputStream, scene::Scene)::union_shape
 


### PR DESCRIPTION
This PR is meant to update composed shape in scene definition.

In order to do this:
- [ ] add shape definition with variable name for csg
- [ ] think a way to define shapes without adding them to world variable
- [ ] variable name should be defined also for union, difference and intersection
- [ ] should think a way to add final shapes to the world variable